### PR TITLE
Add .strip to API Key loading call

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -139,7 +139,8 @@ def gpt3_completion(prompt, engine='text-davinci-003', temp=0.0, top_p=1.0, toke
 
 
 if __name__ == '__main__':
-    openai.api_key = open_file('openaiapikey.txt')
+    # Use .strip() to remove any potential \n at end of APIkey which causes error
+    openai.api_key = open_file('openaiapikey.txt').strip()
     while True:
         #### get user input, save it, vectorize it, etc
         a = input('\n\nUSER: ')


### PR DESCRIPTION
Testers received error that the call could not complete, obviously pointing to the Bearer token on the call to the OpenAI API. We noticed that even if the file was obviously a single line, and was created with e.g. echo [apiKey] > openaiapikey.txt  the error would occur. Somehow a newline is being appended somewhere and being an annoyance, and this fixes that proactively.