### PR TITLE
Remove the requirement to strip newlines from openaiapikey.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GPT-3 chatbot with long-term memory and external sources.
 2.  Create a virtual environment: `python3 -m venv env`
 3.  Activate the environment: `.\env\Scripts\activate`
 4.  Install the required packages: `pip install openai numpy`
-5.  Copy your OpenAI api key to a file named `openaiapikey.txt` in the project directory. Ensure there is no trailing newline.
+5.  Copy your OpenAI api key to a file named `openaiapikey.txt` in the project directory.
 
 ### Mac/Linux
 
@@ -23,7 +23,7 @@ GPT-3 chatbot with long-term memory and external sources.
 2.  Create a virtual environment: `python3 -m venv env`
 3.  Activate the environment: `source env/bin/activate`
 4.  Install the required packages: `pip3 install openai numpy`
-5.  Copy your OpenAI api key to a file named `openaiapikey.txt` in the project directory. Ensure there is no trailing newline.
+5.  Copy your OpenAI api key to a file named `openaiapikey.txt` in the project directory.
 
 ## Usage
 

--- a/chat.py
+++ b/chat.py
@@ -139,7 +139,7 @@ def gpt3_completion(prompt, engine='text-davinci-003', temp=0.0, top_p=1.0, toke
 
 
 if __name__ == '__main__':
-    openai.api_key = open_file('openaiapikey.txt')
+    openai.api_key = open_file('openaiapikey.txt').rstrip()
     while True:
         #### get user input, save it, vectorize it, etc
         a = input('\n\nUSER: ')


### PR DESCRIPTION
On macOS most editors default to saving a trailing newline even when none is entered.

Also allows users some grace if they accidentally add a space to the end of the API key.